### PR TITLE
Fix static path (change to tmpFolder)

### DIFF
--- a/nivel-04/01-arquitetura-e-testes-no-nodejs/src/shared/infra/http/server.ts
+++ b/nivel-04/01-arquitetura-e-testes-no-nodejs/src/shared/infra/http/server.ts
@@ -15,7 +15,7 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
-app.use('/files', express.static(uploadConfig.directory));
+app.use('/files', express.static(uploadConfig.tmpFolder));
 app.use(routes);
 
 app.use((err: Error, request: Request, response: Response, _: NextFunction) => {


### PR DESCRIPTION
The current express static path doesn't exist. It has been refactored on video and it's now called ``tmpFolder``.

Signed-off-by: Dayvson Sales <dayvson@outlook.com>